### PR TITLE
#34 Multi-leveled generics generates wrong registration

### DIFF
--- a/.github/workflows/BuildTest.yml
+++ b/.github/workflows/BuildTest.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
 
       - name: Check out
         uses: actions/checkout@v4

--- a/.github/workflows/BuildTestPackPublish.yml
+++ b/.github/workflows/BuildTestPackPublish.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
 
       - name: Check out
         uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -399,3 +399,4 @@ FodyWeavers.xsd
 
 # Generated files
 /Examples/BlazorApp/BlazorApp/Generated/Microsoft.NET.Sdk.Razor.SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator
+/Examples/BlazorApp/BlazorApp/Generated/Microsoft.CodeAnalysis.Razor.Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator

--- a/Analyzer/DISourceGeneratorAnalyzer.Vsix/DISourceGeneratorAnalyzer.Vsix.csproj
+++ b/Analyzer/DISourceGeneratorAnalyzer.Vsix/DISourceGeneratorAnalyzer.Vsix.csproj
@@ -19,7 +19,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.8.3038" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.13.2126" PrivateAssets="all" />
 	</ItemGroup>
 
 	<PropertyGroup>

--- a/DISourceGenerator.UnitTests/Mdk.DISourceGenerator.UnitTests.csproj
+++ b/DISourceGenerator.UnitTests/Mdk.DISourceGenerator.UnitTests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 
@@ -10,25 +10,24 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-		<PackageReference Include="xunit" Version="2.6.6" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.0">
+		<PackageReference Include="coverlet.collector" Version="6.0.4">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.1" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.1" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.XUnit" Version="1.1.1" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.2" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.XUnit" Version="1.1.2" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\DISourceGenerator\Mdk.DISourceGenerator.csproj"
-						  OutputItemType="Analyzer"/>
+		<ProjectReference Include="..\DISourceGenerator\Mdk.DISourceGenerator.csproj" OutputItemType="Analyzer" />
 	</ItemGroup>
 </Project>

--- a/DISourceGenerator/Lib/Parts/DIAttributePart.cs
+++ b/DISourceGenerator/Lib/Parts/DIAttributePart.cs
@@ -48,22 +48,17 @@ internal abstract class DIAttributePart(AttributeData attribute) : DIPart
         if (this.NamedTypeSymbol is not INamedTypeSymbol attributeParameterType)
             return this._asString = string.Empty;
 
-        if (attributeParameterType is not null)
+        string? genericPart = null;
+        if (attributeParameterType.IsUnboundGenericType)
         {
-            string? genericPart = null;
-            if (attributeParameterType.IsUnboundGenericType)
-            {
-                genericPart = $"<{new string(',', attributeParameterType.TypeArguments.Length - 1)}>";
-            }
-            else if (attributeParameterType.IsGenericType)
-            {
-                genericPart = $"<{string.Join(", ", attributeParameterType.TypeArguments.Select(type => type.OriginalDefinition))}>";
-            }
-
-            return this._asString = $"global::{attributeParameterType.ContainingNamespace}.{attributeParameterType.Name}{genericPart}";
+            genericPart = $"<{new string(',', attributeParameterType.TypeArguments.Length - 1)}>";
+        }
+        else if (attributeParameterType.IsGenericType)
+        {
+            genericPart = $"<{string.Join(", ", attributeParameterType.TypeArguments)}>";
         }
 
-        return this._asString = string.Empty;
+        return this._asString = $"global::{attributeParameterType.ContainingNamespace}.{attributeParameterType.Name}{genericPart}";
     }
     private string? _asString;
 }

--- a/DISourceGenerator/Mdk.DISourceGenerator.csproj
+++ b/DISourceGenerator/Mdk.DISourceGenerator.csproj
@@ -7,7 +7,7 @@
 		<IsRoslynComponent>true</IsRoslynComponent>
 		<Nullable>enable</Nullable>
 		<LangVersion>latest</LangVersion>
-		<Version>1.3.0</Version>
+		<Version>1.3.1</Version>
 		<Authors>Michel de Kok</Authors>
 		<Company>Michel de Kok Software Engineering</Company>
 		<RepositoryUrl>https://github.com/mdekok/mdk-di-sourcegenerator</RepositoryUrl>
@@ -21,9 +21,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.13.0" />
 		<!-- Add Mdk.DIAttributes to be a transitive reference for clients. So only Mdk.DISourceGenerator has to be referenced by clients. -->
 		<PackageReference Include="Mdk.DIAttributes" Version="1.0.1" />
 	</ItemGroup>

--- a/Development/DevConsoleApp/DevConsoleApp.csproj
+++ b/Development/DevConsoleApp/DevConsoleApp.csproj
@@ -2,13 +2,13 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Development/ReferencedLibrary/ReferencedLibrary.csproj
+++ b/Development/ReferencedLibrary/ReferencedLibrary.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Examples/BaseBusinessLogic/BusinessBaseLogic.csproj
+++ b/Examples/BaseBusinessLogic/BusinessBaseLogic.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Mdk.DISourceGenerator" Version="1.1.0" />
+		<PackageReference Include="Mdk.DISourceGenerator" Version="1.2.0" />
 	</ItemGroup>
 
 	<!-- Add generated files to source control. -->

--- a/Examples/BlazorApp/BlazorApp.Client/BlazorApp.Client.csproj
+++ b/Examples/BlazorApp/BlazorApp.Client/BlazorApp.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.4" />
   </ItemGroup>
 
 </Project>

--- a/Examples/BlazorApp/BlazorApp/BlazorApp.csproj
+++ b/Examples/BlazorApp/BlazorApp/BlazorApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 	</PropertyGroup>
@@ -9,7 +9,7 @@
 	<ItemGroup>
 		<ProjectReference Include="..\..\BusinessLogic\BusinessLogic.csproj" />
 		<ProjectReference Include="..\BlazorApp.Client\BlazorApp.Client.csproj" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.1" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.4" />
 	</ItemGroup>
 
 	<!-- Add generated files to source control. -->

--- a/Examples/BusinessLogic/BusinessLogic.csproj
+++ b/Examples/BusinessLogic/BusinessLogic.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/Examples/MinimalApi/MinimalApi.csproj
+++ b/Examples/MinimalApi/MinimalApi.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<InvariantGlobalization>true</InvariantGlobalization>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.1" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Fix is in DIAttributePart.cs

Update dependencies and enhance tests for .NET 9
- Added `FodyWeavers.xsd` to `.gitignore`.
- Updated `Microsoft.VSSDK.BuildTools` to version `17.13.2126`.
- Renamed test method `InvalidAttribute_GeneratesNoRegistration` to `InvalidAttributeName_GeneratesNoRegistration`.
- Added new tests for interface registrations, multi-level generics, and request-response patterns.
- Upgraded target framework from `net8.0` to `net9.0` across multiple projects.
- Updated various package references, including `Microsoft.Extensions.Hosting` and `Microsoft.AspNetCore` packages.
- Updated `Microsoft.CodeAnalysis.Analyzers` and `Microsoft.CodeAnalysis.CSharp` packages to newer versions.
- Incremented `Mdk.DISourceGenerator` project version from `1.3.0` to `1.3.1`.
- Updated `coverlet.collector` to version `6.0.4`.
- Updated testing packages to version `1.1.2`.