### PR TITLE
#37 Don't output CodeAnalysis dll's

### DIFF
--- a/DISourceGenerator/Mdk.DISourceGenerator.csproj
+++ b/DISourceGenerator/Mdk.DISourceGenerator.csproj
@@ -7,7 +7,7 @@
 		<IsRoslynComponent>true</IsRoslynComponent>
 		<Nullable>enable</Nullable>
 		<LangVersion>latest</LangVersion>
-		<Version>1.3.1</Version>
+		<Version>1.3.2</Version>
 		<Authors>Michel de Kok</Authors>
 		<Company>Michel de Kok Software Engineering</Company>
 		<RepositoryUrl>https://github.com/mdekok/mdk-di-sourcegenerator</RepositoryUrl>
@@ -18,12 +18,13 @@
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageTags>DI;Dependency Injection;Attributes;Reflection;Incremental;Source;Generator;Analyzer</PackageTags>
+		<SatelliteResourceLanguages>en</SatelliteResourceLanguages>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.13.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.13.0" PrivateAssets="all" />
 		<!-- Add Mdk.DIAttributes to be a transitive reference for clients. So only Mdk.DISourceGenerator has to be referenced by clients. -->
 		<PackageReference Include="Mdk.DIAttributes" Version="1.0.1" />
 	</ItemGroup>
@@ -43,10 +44,4 @@
 	<ItemGroup>
 		<None Update="tools\*.ps1" CopyToOutputDirectory="PreserveNewest" Pack="true" PackagePath="" />
 	</ItemGroup>
-
-	<!--<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.2.0" PrivateAssets="all" />
-		<PackageReference Update="NETStandard.Library" PrivateAssets="all" />
-	</ItemGroup>-->
-
 </Project>	

--- a/Examples/BaseBusinessLogic/BusinessBaseLogic.csproj
+++ b/Examples/BaseBusinessLogic/BusinessBaseLogic.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Mdk.DISourceGenerator" Version="1.2.0" />
+		<PackageReference Include="Mdk.DISourceGenerator" Version="1.3.1" />
 	</ItemGroup>
 
 	<!-- Add generated files to source control. -->


### PR DESCRIPTION
Update Mdk.DISourceGenerator to version 1.3.2

- Added `PrivateAssets` attribute to `Microsoft.CodeAnalysis.CSharp.Workspaces` reference.
- Introduced `<SatelliteResourceLanguages>en</SatelliteResourceLanguages>` property.
- Removed unused package references and comments for cleaner configuration.